### PR TITLE
fix(poll-schedule):  prevent manual date input and display today's date as placeholder

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -5,7 +5,8 @@
     "packageManager": "npm",
     "schematicCollections": [
       "angular-eslint"
-    ]
+    ],
+    "analytics": false
   },
   "newProjectRoot": "projects",
   "projects": {

--- a/src/app/poll-details/poll-details-overview/poll-details-overview.component.html
+++ b/src/app/poll-details/poll-details-overview/poll-details-overview.component.html
@@ -39,7 +39,7 @@
         <section class="flex gap-2 flex-wrap">
           <mat-form-field appearance="outline" class="flex-1 min-w-[140px]">
             <mat-label>Start Date</mat-label>
-            <input matInput [matDatepicker]="startDatePicker" [min]="minDate()" [(ngModel)]="startDate">
+            <input matInput [matDatepicker]="startDatePicker" [min]="minDate()" [(ngModel)]="startDate" placeholder="{{ minDate() | date:'MM/dd/yyyy' }}" readonly>
             <mat-datepicker-toggle matSuffix [for]="startDatePicker"></mat-datepicker-toggle>
             <mat-datepicker #startDatePicker></mat-datepicker>
           </mat-form-field>
@@ -51,7 +51,7 @@
         <section class="flex gap-2 flex-wrap">
           <mat-form-field appearance="outline" class="flex-1 min-w-[140px]">
             <mat-label>End Date</mat-label>
-            <input matInput [matDatepicker]="endDatePicker" [min]="startDate()" [(ngModel)]="endDate">
+            <input matInput [matDatepicker]="endDatePicker" [min]="startDate()" [(ngModel)]="endDate" readonly>
             <mat-datepicker-toggle matSuffix [for]="endDatePicker"></mat-datepicker-toggle>
             <mat-datepicker #endDatePicker></mat-datepicker>
           </mat-form-field>


### PR DESCRIPTION
<img width="1919" height="938" alt="Screenshot 2026-02-26 203313" src="https://github.com/user-attachments/assets/41483dce-8714-494a-aa4f-99a981232996" />

You can’t type in the date fields anymore they’re set to readonly 