### PR TITLE
fix(poll-description): fix textarea resize issue in edit/update poll

### DIFF
--- a/src/app/groups/components/group-form/group-form.component.html
+++ b/src/app/groups/components/group-form/group-form.component.html
@@ -15,7 +15,7 @@
 
     <mat-form-field appearance="outline" class="w-full">
       <mat-label>Group Description</mat-label>
-      <textarea matInput type="text" [formField]="groupForm.description"></textarea>
+      <textarea matInput cdkTextareaAutosize style="resize: vertical; min-height: 50px; max-height: 250px; overflow-y: auto;" [formField]="groupForm.description"></textarea>
       @if (groupForm.description().touched() && groupForm.description().required()) {
         <mat-error>Group description is required</mat-error>
       }

--- a/src/app/polls/components/poll-form/poll-form.component.html
+++ b/src/app/polls/components/poll-form/poll-form.component.html
@@ -15,7 +15,7 @@
 
     <mat-form-field appearance="outline" class="w-full">
       <mat-label>Poll Description</mat-label>
-      <textarea matInput type="text" [formField]="pollForm.description"></textarea>
+      <textarea matInput cdkTextareaAutosize style="resize: vertical; min-height: 50px; max-height: 250px; overflow-y: auto;" [formField]="pollForm.description"></textarea>
       @if (pollForm.description().touched() && pollForm.description().required()) {
         <mat-error>Poll description is required</mat-error>
       }

--- a/src/app/workspaces/components/workspace-form/workspace-form.component.html
+++ b/src/app/workspaces/components/workspace-form/workspace-form.component.html
@@ -15,7 +15,7 @@
 
     <mat-form-field appearance="outline" class="w-full">
       <mat-label>Workspace Description</mat-label>
-      <textarea matInput type="text" [formField]="workspaceForm.description" placeholder="Workspace Description"></textarea>
+      <textarea matInput cdkTextareaAutosize style="resize: vertical; min-height: 50px; max-height: 250px; overflow-y: auto;"[formField]="workspaceForm.description" placeholder="Workspace Description"></textarea>
       @if (workspaceForm.description().touched() && workspaceForm.description().required()) {
         <mat-error>Workspace description is required</mat-error>
       }


### PR DESCRIPTION
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/d09c3753-7b8c-413a-b4c0-dba5ccd9790a" />


Applied the textarea resize fix to Groups and Workspaces forms as well