### PR TITLE
fix(poll-time): text clipping in poll start and end time inputs

### DIFF
--- a/src/app/poll-details/poll-details-overview/poll-details-overview.component.html
+++ b/src/app/poll-details/poll-details-overview/poll-details-overview.component.html
@@ -45,7 +45,7 @@
           </mat-form-field>
           <mat-form-field appearance="outline" class="w-40">
             <mat-label>Start Time</mat-label>
-            <input matInput type="time" [(ngModel)]="startTime">
+            <input matInput type="time" [(ngModel)]="startTime" style="overflow: visible; padding-bottom: 4px;">
           </mat-form-field>
         </section>
         <section class="flex gap-2 flex-wrap">
@@ -57,7 +57,7 @@
           </mat-form-field>
           <mat-form-field appearance="outline" class="w-40">
             <mat-label>End Time</mat-label>
-            <input matInput type="time" [min]="startTime()" [(ngModel)]="endTime">
+            <input matInput type="time" [min]="startTime()" [(ngModel)]="endTime" style="overflow: visible; padding-bottom: 4px;">
           </mat-form-field>
         </section>
       </section>


### PR DESCRIPTION
<img width="277" height="231" alt="image" src="https://github.com/user-attachments/assets/2e76b5a8-51b3-4f4b-9499-8142e2fe1567" />
