### PR TITLE
fix(poll): correct delete confirmation popup text from 'User' to 'Poll'

### DIFF
--- a/src/app/polls/components/poll-delete-confirmation/poll-delete-confirmation.component.html
+++ b/src/app/polls/components/poll-delete-confirmation/poll-delete-confirmation.component.html
@@ -1,13 +1,13 @@
 <section class="flex flex-col gap-4 px-8 py-6 mat-bg-surface-container-lowest">
-  <h2 class="text-2xl font-bold">Are you sure you want to delete this user?</h2>
-  <p>This action cannot be undone. This will permanently delete the user and all associated data.</p>
+  <h2 class="text-2xl font-bold">Are you sure you want to delete this Poll?</h2>
+  <p>This action cannot be undone. This will permanently delete the poll and all associated data.</p>
   <section class="flex justify-end gap-2">
     <button matButton="filled" color="primary" (click)="deletePoll()" [disabled]="deletingPollLoading()">
       <div class="flex items-center gap-2">
         @if (deletingPollLoading()) {
           <mat-progress-spinner mode="indeterminate" diameter="20"></mat-progress-spinner>
         }
-        <span>Delete User</span>
+        <span>Delete Poll</span>
       </div>
     </button>
     <button matButton="tonal" color="primary" (click)="closeDialog()">Cancel</button>


### PR DESCRIPTION
<img width="1919" height="935" alt="Screenshot 2026-03-17 081608" src="https://github.com/user-attachments/assets/c9dd7eb9-2934-412d-a5ba-cd971b9ce68d" />
