### PR TITLE
fix(poll): prevent selecting past end dates and enforce end date after start date

### DIFF
--- a/src/app/poll-details/poll-details-overview/poll-details-overview.component.html
+++ b/src/app/poll-details/poll-details-overview/poll-details-overview.component.html
@@ -51,7 +51,7 @@
         <section class="flex gap-2 flex-wrap">
           <mat-form-field appearance="outline" class="flex-1 min-w-[140px]">
             <mat-label>End Date</mat-label>
-            <input matInput [matDatepicker]="endDatePicker" [min]="startDate()" [(ngModel)]="endDate" readonly [disabled]="!isPollDraft()">
+            <input matInput [matDatepicker]="endDatePicker" [min]="minDate()" [(ngModel)]="endDate" readonly [disabled]="!isPollDraft()">
             <mat-datepicker-toggle matSuffix [for]="endDatePicker" [disabled]="!isPollDraft()"></mat-datepicker-toggle>
             <mat-datepicker #endDatePicker></mat-datepicker>
           </mat-form-field>


### PR DESCRIPTION
<img width="1919" height="933" alt="image" src="https://github.com/user-attachments/assets/79375d88-fc9e-43b1-ab65-9434df007e41" />


This issue was already implemented and addressed in a previous ticket, so no additional changes are needed at this time