### PR TITLE
fix(poll): disable schedule button when start and end time are the same

### DIFF
--- a/src/app/poll-details/poll-details-overview/poll-details-overview.component.html
+++ b/src/app/poll-details/poll-details-overview/poll-details-overview.component.html
@@ -66,7 +66,7 @@
           <button matButton="outlined" color="primary" (click)="resetPollDuration()">
             <span>Reset</span>
           </button>
-          <button matButton="filled" color="primary" (click)="setPollDuration()">
+          <button matButton="filled" color="primary" (click)="setPollDuration()" [disabled]="isScheduleInvalid()">
             <span>Set poll schedule</span>
           </button>
         </section>

--- a/src/app/poll-details/poll-details-overview/poll-details-overview.component.ts
+++ b/src/app/poll-details/poll-details-overview/poll-details-overview.component.ts
@@ -50,6 +50,7 @@ export class PollDetailsOverviewComponent {
   public startTime = signal<string>('09:00');
   public endDate = signal<Date | null>(null);
   public endTime = signal<string>('17:00');
+  public isScheduleInvalid = computed(() => this.endTime() === this.startTime());
   public minDate = computed(() => new Date());
 
   public startDateTime = computed(() => {


### PR DESCRIPTION
<img width="1045" height="445" alt="image" src="https://github.com/user-attachments/assets/66c39a4b-45f2-4f26-a45f-f771472f2981" />


it will disable the set poll schedule button when start and end time are the same